### PR TITLE
Blip Bounty /blipbounty taikai page redirect

### DIFF
--- a/content/en/taikai-redirect.md
+++ b/content/en/taikai-redirect.md
@@ -1,0 +1,10 @@
+---
+title: ""
+description: ""
+images: []
+layout: page
+containerClass: "page-cards"
+url: "/blipbounty/"
+---
+
+<meta http-equiv="refresh" content="0; URL=https://taikai.network/en/baselineprotocol/hackathons/blipbounty"/>


### PR DESCRIPTION
This change adds a redirect on the https://baseline-protocol.org/blipbounty page that takes the user to our TAIKAI event page here: https://taikai.network/en/baselineprotocol/hackathons/blipbounty

This can be used to distribute the link while keeping our domain.